### PR TITLE
Fixexception smtp

### DIFF
--- a/cloudmra/aliashandler.py
+++ b/cloudmra/aliashandler.py
@@ -52,3 +52,7 @@ class aliashandler():
 			return response
 		else:
 			return response + '@' + host
+		
+if __name__ == "__main__":
+	print("ERROR: This module should not be called directly.")
+	exit(1)

--- a/cloudmra/cloudhandler.py
+++ b/cloudmra/cloudhandler.py
@@ -57,3 +57,7 @@ class cloudhandler():
 		handle[1].delete()
 		self.expire_bucket.copy( {'Bucket': handle[2].bucket_name, 'Key': handle[2].key}, handle[2].key)
 		handle[2].delete()
+		
+if __name__ == "__main__":
+	print("ERROR: This module should not be called directly.")
+	exit(1)

--- a/cloudmra/deliveryhandler.py
+++ b/cloudmra/deliveryhandler.py
@@ -18,7 +18,11 @@ class deliveryhandler():
 			return self.INVALIDUSER
 		except (smtplib.SMTPServerDisconnected, smtplib.SMTPSenderRefused):
 			self.lmtp.connect(host=self.hostname, port=self.port)
-			self.lmtp.sendmail(from_addr='', to_addrs=receipient, msg=message)
+			try:
+				self.lmtp.sendmail(from_addr='', to_addrs=receipient, msg=message)
+			except smtplib.SMTPRecipientsRefused :
+				return self.INVALIDUSER
+
 		return True
 			
 if __name__ == "__main__":


### PR DESCRIPTION
Added an exception handler around the inner branch in deliveryhandler. This fixes a bug where the LMTP time-out would cause the code to branch such that a subsequent delivery that was to an account not explicitly defined (so an alias or to be caught by default address,) would not be caught and result in abnormal termination.